### PR TITLE
fix: update actions/cache to v4.2.3

### DIFF
--- a/setup-zephyr-sdk/action.yml
+++ b/setup-zephyr-sdk/action.yml
@@ -21,7 +21,7 @@ runs:
     # TODO: Validate arguments
     - name: Restore Zephyr SDK Cache
       id: cache-zephyr-sdk
-      uses: actions/cache@v4.0.2
+      uses: actions/cache@v4.2.3
       with:
         # TODO: Hash toolchains probably?
         key: zephyr-sdk-${{ runner.os }}-${{ inputs.version }}-${{ inputs.toolchains }}


### PR DESCRIPTION
This commit updates the version of actions/cache from v4.0.2 to v4.2.3 to resolve a CI failure caused by the older version no longer being available.