### PR TITLE
fix: add composite actions to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      # NOTE: Workaround to fix issue where composite actions
+      # are not bumped automatically.
+      # https://github.com/dependabot/dependabot-core/issues/6704
+      - "/*/action.yml"
     schedule:
       interval: "weekly"
       day: "saturday"

--- a/setup-zephyr-sdk/action.yml
+++ b/setup-zephyr-sdk/action.yml
@@ -21,7 +21,7 @@ runs:
     # TODO: Validate arguments
     - name: Restore Zephyr SDK Cache
       id: cache-zephyr-sdk
-      uses: actions/cache@v4.2.3
+      uses: actions/cache@v4.2.2
       with:
         # TODO: Hash toolchains probably?
         key: zephyr-sdk-${{ runner.os }}-${{ inputs.version }}-${{ inputs.toolchains }}


### PR DESCRIPTION
This commit fixes an issue where GitHub Actions dependencies in composite actions are not bumped by Dependabot[1]. To resolve this, the existing workaround is to specify the paths of the composite actions explicitly.

As part of this, we also rollback one of the dependencies to an earlier version so we can validate the fix.

[1]: https://github.com/dependabot/dependabot-core/issues/6704