### PR TITLE
ci: pin actions by commit hash


### DIFF
--- a/.github/workflows/setup-kicad-library-utils.yml
+++ b/.github/workflows/setup-kicad-library-utils.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Run action
         uses: ./setup-kicad-library-utils
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Run action
         uses: ./setup-kicad-library-utils

--- a/.github/workflows/setup-kicad.yml
+++ b/.github/workflows/setup-kicad.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Run action
         uses: ./setup-kicad

--- a/.github/workflows/setup-zephyr-sdk.yml
+++ b/.github/workflows/setup-zephyr-sdk.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Run action
         uses: ./setup-zephyr-sdk


### PR DESCRIPTION
This commit updates the various actions to pin by hash instead of tag.

Pinning by hash is widely considered to be best practice. Considering
that Dependabot now has the ability to bump actions by hash[1], it makes
sense to switch to pinning by hash.

[1]: https://github.com/dependabot/dependabot-core/issues/4691
